### PR TITLE
Update docker compose usage

### DIFF
--- a/.ci_helpers/docker/setup-services.py
+++ b/.ci_helpers/docker/setup-services.py
@@ -118,14 +118,15 @@ if __name__ == "__main__":
                 commands.append(
                     {
                         "msg": "Pulling latest images ...",
-                        "cmd": ["docker-compose", "-f", COMPOSE_FILE, "pull"],
+                        "cmd": ["docker", "compose", "-f", COMPOSE_FILE, "pull"],
                     }
                 )
             commands.append(
                 {
                     "msg": "Bringing up services ...",
                     "cmd": [
-                        "docker-compose",
+                        "docker",
+                        "compose",
                         "-f",
                         COMPOSE_FILE,
                         "up",
@@ -160,7 +161,7 @@ if __name__ == "__main__":
         commands.append({"msg": "Setting up minio s3 bucket ...", "cmd": load_s3})
 
     if args.tear_down:
-        command = ["docker-compose", "-f", COMPOSE_FILE, "down", "--remove-orphans", "--volumes"]
+        command = ["docker", "compose", "-f", COMPOSE_FILE, "down", "--remove-orphans", "--volumes"]
         if args.images:
             command = command + ["--rmi", "all"]
         commands.append({"msg": "Stopping test services deployment ...", "cmd": command})

--- a/docs/source/contrib_setup.md
+++ b/docs/source/contrib_setup.md
@@ -71,7 +71,7 @@ to keep test data versioned and directly associated with the repo.
 
 To run echopype tests found in `echopype/tests`,
 [`Docker`](https://docs.docker.com/get-docker/) needs to be installed.
-[`docker-compose`](https://docs.docker.com/compose/) is also needed,
+The [`docker compose` plugin](https://docs.docker.com/compose/) is also needed,
 but it should already be installed in the development environment created above.
 
 To run the tests:


### PR DESCRIPTION
## Summary
- switch docker-compose CLI calls to `docker compose` in the setup script
- document `docker compose` plugin in contributor docs

## Testing
- `python .ci_helpers/docker/setup-services.py --deploy --no-pull` *(fails: FileNotFoundError: 'docker')*
- `python .ci_helpers/docker/setup-services.py --tear-down` *(fails: FileNotFoundError: 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_68543f2477408331bfc7f828cbf67305