### PR TITLE
Add local PR check script

### DIFF
--- a/docs/source/contrib_setup.md
+++ b/docs/source/contrib_setup.md
@@ -78,14 +78,14 @@ To run the tests:
 ```shell
 # Install and/or deploy the echopype docker containers for testing.
 # Test data files will be downloaded
-python .ci_helpers/docker/setup-services.py --deploy
+uv run .ci_helpers/docker/setup-services.py --deploy
 
 # Run all the tests. But first make sure the
 # echopype development conda environment is activated
-python .ci_helpers/run-test.py --local --pytest-args="-vv"
+uv run .ci_helpers/run-test.py --local --pytest-args="-vv"
 
 # When done, "tear down" the docker containers
-python .ci_helpers/docker/setup-services.py --tear-down
+uv run .ci_helpers/docker/setup-services.py --tear-down
 ```
 
 The tests include reading and writing from locally set up (via docker)
@@ -99,17 +99,27 @@ You can use `run-test.py` to run only tests for specific subpackages
 (`convert`, `calibrate`, etc) by passing a comma-separated list:
 ```shell
 # Run only tests associated with the calibrate and mask subpackages
-python .ci_helpers/run-test.py --local --pytest-args="-vv" echopype/calibrate/calibrate_ek.py,echopype/mask/api.py
+uv run .ci_helpers/run-test.py --local --pytest-args="-vv" echopype/calibrate/calibrate_ek.py,echopype/mask/api.py
 ```
 or specific test files by passing a comma-separated list:
 ```shell
 # Run only tests in the test_convert_azfp.py and test_noise.py files
-python .ci_helpers/run-test.py --local --pytest-args="-vv"  echopype/tests/convert/test_convert_azfp.py,echopype/tests/clean/test_noise.py
+uv run .ci_helpers/run-test.py --local --pytest-args="-vv"  echopype/tests/convert/test_convert_azfp.py,echopype/tests/clean/test_noise.py
 ```
 
 For `run-test.py` usage information, use the ``-h`` argument:
 ```shell
-`python .ci_helpers/run-test.py -h`
+`uv run .ci_helpers/run-test.py -h`
+```
+
+``scripts/run_pr_checks.sh`` combines these steps by running the pre-commit
+hooks on the staged files, deploying the test services, running tests only for
+files changed relative to ``origin/main`` with coverage enabled, and then
+tearing the services down. Execute it from the repository root before opening a
+pull request:
+
+```shell
+scripts/run_pr_checks.sh
 ```
 
 

--- a/scripts/run_pr_checks.sh
+++ b/scripts/run_pr_checks.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run pre-commit on staged files
+STAGED_FILES=$(git diff --cached --name-only)
+if [[ -n "$STAGED_FILES" ]]; then
+    pre-commit run --files $STAGED_FILES
+fi
+
+# Ensure services are torn down on exit
+trap 'uv run .ci_helpers/docker/setup-services.py --tear-down' EXIT
+
+uv run .ci_helpers/docker/setup-services.py --deploy
+
+CHANGED_FILES=$(git diff --name-only origin/main...HEAD | tr '\n' ',' | sed 's/,$//')
+
+NUM_WORKERS=${NUM_WORKERS:-2}
+
+uv run .ci_helpers/run-test.py --local \
+    --pytest-args="--log-cli-level=WARNING,-vvv,-rx,--numprocesses=${NUM_WORKERS},--max-worker-restart=3,--disable-warnings" \
+    --include-cov "$CHANGED_FILES"


### PR DESCRIPTION
## Summary
- add `scripts/run_pr_checks.sh` for local pre-commit and unit tests
- document workflow in `contrib_setup.md`
- invoke helper scripts via `uv run`

## Testing
- `pre-commit run --files scripts/run_pr_checks.sh docs/source/contrib_setup.md`
- `bash scripts/run_pr_checks.sh` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_685457ff8cc883318fb3bf868e4d3bf3