### PR TITLE
Fix ECHOPYPE_DIR path

### DIFF
--- a/echopype/utils/io.py
+++ b/echopype/utils/io.py
@@ -38,7 +38,7 @@ logger = _init_logger(__name__)
 
 # Get root echopype package name
 ECHOPYPE = __name__.split(".")[0]
-ECHOPYPE_DIR = Path(os.path.expanduser("~")) / ".{ECHOPYPE}"
+ECHOPYPE_DIR = Path(os.path.expanduser("~")) / f".{ECHOPYPE}"
 ECHOPYPE_TEMP_DIR = Path(tempfile.gettempdir()) / ECHOPYPE
 _SWAP_PREFIX = "ep-swap"
 


### PR DESCRIPTION
## Summary
- fix definition of ECHOPYPE_DIR

## Testing
- `pytest echopype/tests/utils/test_utils_io.py::test_init_ep_dir -q`
- `pytest echopype/tests/convert/test_convert_azfp.py::test_convert_azfp_UNB_glider_130kHz -q` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68545b5978dc83319d9dccdded2726d5