### PR TITLE
Fix temp directory handling in run-test.py

### DIFF
--- a/.ci_helpers/run-test.py
+++ b/.ci_helpers/run-test.py
@@ -62,7 +62,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
     if args.local:
-        temp_path = Path("~/.echopype/temp_output")
+        temp_path = Path("~/.echopype/temp_output").expanduser()
         dump_path = Path("echopype/test_data/dump")
         if temp_path.exists():
             shutil.rmtree(temp_path)


### PR DESCRIPTION
## Summary
- fix user path resolution in run-test.py

## Testing
- `pre-commit run --files .ci_helpers/run-test.py`
- `pytest echopype/tests/test_core.py::test_file_extension_validation -vv`

------
https://chatgpt.com/codex/tasks/task_e_68545ccec09c8331abc63f678e26c460